### PR TITLE
Maid 1025: Test Pure Sentinel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cbor = "*"
 sodiumoxide = "0.0.5"
 rand = "*"
 #accumulator = "0.0.1"
-lru_time_cache = "0.1.6"
+lru_time_cache = "0.1.7"
 
 [dependencies.accumulator]
 git = "https://github.com/inetic/accumulator"

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -121,20 +121,20 @@ impl<Request, Name>
     /// the request and the verified and merged claim is returned.
     /// Otherwise None is returned.
     pub fn add_keys(&mut self, request : Request, sender: Name, keys : Vec<(Name, PublicKey)>)
-          -> Option<(Request, SerialisedClaim)> {
-          // We don't want to store keys for requests we haven't received yet because
-          // we couldn't have requested those keys. So someone is probably trying
-          // something silly.
-          if !self.claim_accumulator.contains_key(&request) {
-              return None;
-          }
+        -> Option<(Request, SerialisedClaim)> {
+        // We don't want to store keys for requests we haven't received yet because
+        // we couldn't have requested those keys. So someone is probably trying
+        // something silly.
+        if !self.claim_accumulator.contains_key(&request) {
+            return None;
+        }
 
-          for (target, public_key) in keys {
-              self.key_store.add_key(target, sender.clone(), public_key);
-          }
+        for (target, public_key) in keys {
+            self.key_store.add_key(target, sender.clone(), public_key);
+        }
 
-          self.claim_accumulator.get(&request)
-              .and_then(|(request, claims)| { self.resolve(request, claims) })
+        self.claim_accumulator.get(&request)
+            .and_then(|(request, claims)| { self.resolve(request, claims) })
     }
 
     /// Verify is only concerned with checking the signatures of the serialised claims.
@@ -346,13 +346,18 @@ mod test {
                 }));
         }
 
+        // adds one extra key
+        let key_pair = crypto::sign::gen_keypair();
+        let climant_name = generate_random_name();
+        name_key_pairs.push((climant_name.clone(), key_pair.0.clone()));
+
         // less than KEY_THRESHOLDS kyes received, should return None
-        for index in 0..KEY_THRESHOLDS - 1 {
+        for index in 0..KEY_THRESHOLDS {
             assert!(sentinel.add_keys(request.clone(), name_key_pairs[index].0.clone(), name_key_pairs.clone()).is_none());
         }
 
         // KEY_THRESHOLDS kyes received, should not return none
-        assert!(sentinel.add_keys(request.clone(), name_key_pairs[KEY_THRESHOLDS - 1].0.clone(), name_key_pairs.clone())
+        assert!(sentinel.add_keys(request.clone(), name_key_pairs[KEY_THRESHOLDS].0.clone(), name_key_pairs.clone())
             .and_then(|result| { assert_eq!(result.1, serialised_claim);
                                  assert_eq!(result.0, request);
                                  Some(result)

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -270,7 +270,7 @@ mod test {
             }).is_some());
 
         // One key is required should pass
-        assert!(sentinel.add_keys(request.clone(), name_key_pairs[0].0.clone(), name_key_pairs.clone())
+        assert!(sentinel.add_keys(request.clone(), generate_random_name(), name_key_pairs.clone())
             .and_then(|result| { assert_eq!(result.1, serialised_claim);
                                  assert_eq!(result.0, request);
                                  Some(result)

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -347,9 +347,7 @@ mod test {
         }
 
         // adds one extra key
-        let key_pair = crypto::sign::gen_keypair();
-        let climant_name = generate_random_name();
-        name_key_pairs.push((climant_name.clone(), key_pair.0.clone()));
+        name_key_pairs.push((generate_random_name(), crypto::sign::gen_keypair().0));
 
         // less than KEY_THRESHOLDS kyes received, should return None
         for index in 0..KEY_THRESHOLDS {

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -346,22 +346,19 @@ mod test {
                 }));
         }
 
-        // adds one extra key
-        name_key_pairs.push((generate_random_name(), crypto::sign::gen_keypair().0));
-
-        // less than KEY_THRESHOLDS kyes received, should return None
+        // less than KEY_THRESHOLDS kyes received, should return None as the vector has the senders
         for index in 0..KEY_THRESHOLDS {
             assert!(sentinel.add_keys(request.clone(), name_key_pairs[index].0.clone(), name_key_pairs.clone()).is_none());
         }
 
         // KEY_THRESHOLDS kyes received, should not return none
-        assert!(sentinel.add_keys(request.clone(), name_key_pairs[KEY_THRESHOLDS].0.clone(), name_key_pairs.clone())
+        assert!(sentinel.add_keys(request.clone(), generate_random_name(), name_key_pairs.clone())
             .and_then(|result| { assert_eq!(result.1, serialised_claim);
                                  assert_eq!(result.0, request);
                                  Some(result)
             }).is_some());
 
         // more than KEY_THRESHOLDS kyes received, should return None
-        assert!(sentinel.add_keys(request, name_key_pairs[KEY_THRESHOLDS - 1].0.clone(), name_key_pairs).is_none());
+        assert!(sentinel.add_keys(request, generate_random_name(), name_key_pairs).is_none());
     }
 }


### PR DESCRIPTION
The test passed for sentinel<1, 1> where one claim is followed by one key being sent.
 For sentinel<10, 10> sending 10 claims and, 10 claimant send public key of the 10 climants should provide 10X10 entries which should suffice for it to pass, while it does not.
To avoid code duplicates, a number of tests are presented in one test. They can be separated if it is required.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/sentinel/18)

<!-- Reviewable:end -->
