### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/maidsafe/sentinel.png?label=ready&title=Ready)](https://waffle.io/maidsafe/sentinel)
 # Sentinel
 
 **Primary Maintainer:**     Peter Jankuliak (peter.jankuliak@maidsafe.net)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/maidsafe/sentinel

This was requested by a real person (user benjaminbollen) on waffle.io, we're not trying to spam you.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/sentinel/30)

<!-- Reviewable:end -->
